### PR TITLE
[CHORE] / 아이템 폴더 구조 개선

### DIFF
--- a/my-react-app/src/App.jsx
+++ b/my-react-app/src/App.jsx
@@ -1,11 +1,11 @@
 import "./App.css";
-import TestPage from "./Test/TestPage";
+import MyPage from "./pages/MyPage/MyPage";
 
 function App() {
   return (
     <div>
-      <h1>메인 페이지</h1>
-      <TestPage />
+      <MyPage></MyPage>
+      {/* <TestPage /> */}
     </div>
   );
 }

--- a/my-react-app/src/Test/TestPage.jsx
+++ b/my-react-app/src/Test/TestPage.jsx
@@ -25,6 +25,7 @@ const TestPage = () => {
         userName="유지훈"
       />
 
+
     </div>
   );
 };

--- a/my-react-app/src/components/mypage/ItemPickerModal.jsx
+++ b/my-react-app/src/components/mypage/ItemPickerModal.jsx
@@ -1,0 +1,13 @@
+import styles from "./ItemPickerModal.module.css";
+
+export default function ItemPickerModal({ type, onClose }) {
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <h3>{type} 변경</h3>
+        <p>보유 아이템 중에서 선택 (기능 연결 예정)</p>
+        <button onClick={onClose}>닫기</button>
+      </div>
+    </div>
+  );
+}

--- a/my-react-app/src/components/mypage/ItemPickerModal.module.css
+++ b/my-react-app/src/components/mypage/ItemPickerModal.module.css
@@ -1,0 +1,145 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.42);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  z-index: 50;
+}
+
+.modal {
+  width: min(560px, 96vw);
+  background: var(--bg-primary);
+  border-radius: 18px;
+  border: 1px solid var(--gray-200);
+  box-shadow: 0 18px 50px rgba(17, 24, 39, 0.22);
+  overflow: hidden;
+}
+
+.header {
+  padding: 14px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  border-bottom: 1px solid var(--gray-200);
+  background: linear-gradient(180deg, var(--bg-eco-light), var(--bg-primary));
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 950;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.desc {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.closeBtn {
+  border: 1px solid var(--gray-200);
+  background: var(--bg-primary);
+  border-radius: 12px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-weight: 900;
+}
+
+.closeBtn:hover {
+  background: var(--gray-50);
+}
+
+.body {
+  padding: 14px;
+}
+
+.emptyBox {
+  padding: 16px;
+  border: 1px dashed var(--gray-300);
+  border-radius: 14px;
+  background: var(--gray-50);
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.list {
+  display: grid;
+  gap: 10px;
+}
+
+.item {
+  text-align: left;
+  border-radius: 14px;
+  border: 1px solid var(--gray-200);
+  background: var(--bg-primary);
+  padding: 12px;
+  cursor: pointer;
+}
+
+.item:hover {
+  background: var(--gray-50);
+}
+
+.selected {
+  border-color: var(--green-300);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.12);
+}
+
+.itemName {
+  font-size: 13px;
+  font-weight: 950;
+}
+
+.itemMeta {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.footer {
+  padding: 14px;
+  border-top: 1px solid var(--gray-200);
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  background: var(--bg-primary);
+}
+
+.ghostBtn,
+.primaryBtn {
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 13px;
+  font-weight: 900;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.ghostBtn {
+  background: var(--bg-primary);
+  border-color: var(--gray-200);
+  color: var(--text-primary);
+}
+
+.ghostBtn:hover {
+  background: var(--gray-50);
+}
+
+.primaryBtn {
+  background: var(--btn-primary);
+  color: #fff;
+}
+
+.primaryBtn:hover:enabled {
+  background: var(--btn-primary-hover);
+}
+
+.primaryBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/my-react-app/src/components/mypage/MyPageTabPanel.jsx
+++ b/my-react-app/src/components/mypage/MyPageTabPanel.jsx
@@ -1,0 +1,6 @@
+export default function MyPageTabPanel({ activeTab }) {
+  if (activeTab === "posts") return <div>내가 쓴 글 리스트</div>;
+  if (activeTab === "diary") return <div>AI 환경 일기 요약</div>;
+  if (activeTab === "items") return <div>보유 아이템 목록</div>;
+  return null;
+}

--- a/my-react-app/src/components/mypage/MyPageTabPanel.module.css
+++ b/my-react-app/src/components/mypage/MyPageTabPanel.module.css
@@ -1,0 +1,116 @@
+.panel {
+  background: var(--bg-primary);
+  border: 1px solid var(--gray-200);
+  border-radius: 18px;
+  padding: 14px;
+  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.06);
+}
+
+.header {
+  margin-bottom: 12px;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 950;
+  letter-spacing: -0.02em;
+}
+
+.sub {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.item {
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid var(--gray-200);
+  background: linear-gradient(180deg, var(--bg-primary), var(--gray-50));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.itemTitle {
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.itemMeta {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.diaryItem {
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid var(--gray-200);
+  background: var(--bg-earth);
+}
+
+.diaryDate {
+  font-size: 12px;
+  font-weight: 900;
+  color: var(--earth-700);
+  margin-bottom: 8px;
+}
+
+.diaryText {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.itemGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+@media (max-width: 520px) {
+  .itemGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.itemChip {
+  border-radius: 14px;
+  border: 1px solid var(--gray-200);
+  background: linear-gradient(180deg, var(--bg-eco-soft), var(--bg-primary));
+  padding: 12px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.itemChip:hover {
+  filter: brightness(0.99);
+}
+
+.itemType {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 950;
+  color: var(--text-eco);
+  background: var(--green-100);
+  border: 1px solid var(--green-200);
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+
+.itemName {
+  display: block;
+  margin-top: 10px;
+  font-size: 13px;
+  font-weight: 900;
+  color: var(--text-primary);
+}

--- a/my-react-app/src/components/mypage/MyPageTabs.jsx
+++ b/my-react-app/src/components/mypage/MyPageTabs.jsx
@@ -1,0 +1,17 @@
+import styles from "./MyPageTabs.module.css";
+
+export default function MyPageTabs({ tabs, activeTab, onChange }) {
+  return (
+    <div className={styles.tabs}>
+      {tabs.map((t) => (
+        <button
+          key={t.key}
+          className={activeTab === t.key ? styles.active : ""}
+          onClick={() => onChange(t.key)}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/my-react-app/src/components/mypage/MyPageTabs.module.css
+++ b/my-react-app/src/components/mypage/MyPageTabs.module.css
@@ -1,0 +1,30 @@
+.tabs {
+  display: flex;
+  gap: 10px;
+  background: var(--bg-primary);
+  border: 1px solid var(--gray-200);
+  border-radius: 18px;
+  padding: 10px;
+  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.06);
+}
+
+.tabBtn {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: var(--gray-50);
+  color: var(--text-secondary);
+  font-weight: 950;
+  cursor: pointer;
+}
+
+.tabBtn:hover {
+  background: var(--gray-100);
+}
+
+.active {
+  background: var(--bg-eco-light);
+  border-color: var(--green-200);
+  color: var(--text-eco);
+}

--- a/my-react-app/src/components/mypage/PointWallet.jsx
+++ b/my-react-app/src/components/mypage/PointWallet.jsx
@@ -1,0 +1,18 @@
+import styles from "./PointWallet.module.css";
+
+export default function PointWallet({ wallet }) {
+  return (
+    <section className={styles.card}>
+      <h3>포인트 지갑</h3>
+
+      <div className={styles.now}>
+        {wallet.nowPoint.toLocaleString()} P
+      </div>
+
+      <ul>
+        <li>누적 획득 {wallet.totalEarnedPoint}P</li>
+        <li>누적 사용 {wallet.totalSpentPoint}P</li>
+      </ul>
+    </section>
+  );
+}

--- a/my-react-app/src/components/mypage/PointWallet.module.css
+++ b/my-react-app/src/components/mypage/PointWallet.module.css
@@ -1,0 +1,109 @@
+.card {
+  background: var(--bg-primary);
+  border: 1px solid var(--gray-200);
+  border-radius: 18px;
+  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.06);
+  padding: 14px;
+}
+
+.header {
+  margin-bottom: 10px;
+}
+
+.title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 950;
+  letter-spacing: -0.02em;
+}
+
+.desc {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.bigPoint {
+  margin-top: 10px;
+  border-radius: 14px;
+  border: 1px solid var(--gray-200);
+  background: radial-gradient(circle at 20% 20%, var(--green-100), var(--bg-primary));
+  padding: 12px;
+}
+
+.bigPointLabel {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.bigPointValue {
+  font-size: 22px;
+  font-weight: 950;
+  letter-spacing: -0.02em;
+  color: var(--text-eco);
+}
+
+.rows {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border: 1px solid var(--gray-200);
+  border-radius: 12px;
+  background: var(--bg-primary);
+}
+
+.rowLabel {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.rowValue {
+  font-size: 13px;
+  font-weight: 900;
+  color: var(--text-primary);
+}
+
+.actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.ghostBtn,
+.dangerBtn {
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 13px;
+  font-weight: 900;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.ghostBtn {
+  background: var(--bg-primary);
+  border-color: var(--gray-200);
+  color: var(--text-primary);
+}
+
+.ghostBtn:hover {
+  background: var(--gray-50);
+}
+
+.dangerBtn {
+  background: var(--btn-danger);
+  color: #fff;
+}
+
+.dangerBtn:hover {
+  filter: brightness(0.95);
+}

--- a/my-react-app/src/components/mypage/ProfileSection.jsx
+++ b/my-react-app/src/components/mypage/ProfileSection.jsx
@@ -1,0 +1,127 @@
+import { useMemo } from "react";
+import Profile from "../common/Profile";
+import styles from "./ProfileSection.module.css";
+
+export default function ProfileSection({ user, onOpenModal }) {
+  const profileProps = useMemo(
+    () => ({
+      presetId: user?.presetId ?? "normal-1",
+      profileImage: user?.profileImage ?? "https://placehold.co/72x72",
+      titleId: user?.titleId ?? "normal-1",
+      badgeId: user?.badgeId ?? "normal-1",
+      userName: user?.userName ?? user?.nickname ?? "사용자",
+    }),
+    [user]
+  );
+
+  return (
+    <section className={styles.wrap}>
+      <div className={styles.inner}>
+        {/* 왼쪽: 프로필 카드 */}
+        <div className={styles.profileCard}>
+          <Profile {...profileProps} />
+        </div>
+
+        {/* 오른쪽: 사용자 상세 정보(세로) + 변경 버튼들 */}
+        <div className={styles.info}>
+          <div className={styles.header}>
+            <h3 className={styles.headerTitle}>사용자 정보</h3>
+            <p className={styles.headerDesc}>
+              
+            </p>
+          </div>
+
+          <div className={styles.form}>
+            <div className={styles.field}>
+              <label className={styles.label}>이름</label>
+              <input
+                className={styles.input}
+                value={user?.userName ?? user?.name ?? ""}
+                placeholder="이름"
+                disabled
+                readOnly
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>닉네임</label>
+              <input
+                className={styles.input}
+                value={user?.nickname ?? ""}
+                placeholder="닉네임"
+                readOnly
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>주소</label>
+              <input
+                className={styles.input}
+                value={user?.address ?? ""}
+                placeholder="주소"
+                readOnly
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>성별</label>
+              <input
+                className={styles.input}
+                value={user?.gender ?? ""}
+                placeholder="성별"
+                disabled
+                readOnly
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>생년월일</label>
+              <input
+                className={styles.input}
+                value={user?.birth ?? user?.birthday ?? ""}
+                placeholder="YYYY-MM-DD"
+                readOnly
+              />
+            </div>
+          </div>
+
+          <div className={styles.divider} />
+
+          <div className={styles.changeArea}>
+            <div className={styles.changeTitle}>아이템 변경</div>
+
+            <div className={styles.actions}>
+              <button
+                type="button"
+                className={styles.actionBtn}
+                onClick={() => onOpenModal("title")}
+              >
+                칭호 변경
+              </button>
+
+              <button
+                type="button"
+                className={styles.actionBtn}
+                onClick={() => onOpenModal("badge")}
+              >
+                뱃지 변경
+              </button>
+
+              <button
+                type="button"
+                className={styles.actionBtn}
+                onClick={() => onOpenModal("bg")}
+              >
+                프로필 배경 변경
+              </button>
+            </div>
+
+            <div className={styles.helper}>
+              
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/my-react-app/src/components/mypage/ProfileSection.module.css
+++ b/my-react-app/src/components/mypage/ProfileSection.module.css
@@ -1,0 +1,148 @@
+.wrap {
+  background: var(--bg-primary);
+  border: 1px solid var(--gray-200);
+  border-radius: 18px;
+  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.06);
+  overflow: hidden;
+}
+
+.inner {
+  padding: 16px;
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+/* 왼쪽 프로필 카드 영역 */
+.profileCard {
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid var(--gray-200);
+  background: var(--bg-primary);
+}
+
+/* 오른쪽 정보영역 */
+.info {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 6px 2px;
+}
+
+.headerTitle {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 950;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+.headerDesc {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* 사용자 정보 폼 */
+.form {
+  display: grid;
+  gap: 10px;
+}
+
+.field {
+  display: grid;
+  grid-template-columns: 86px 1fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 900;
+  color: var(--text-secondary);
+}
+
+.input {
+  width: 100%;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid var(--gray-200);
+  padding: 0 12px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.input::placeholder {
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.input:disabled {
+  background: var(--gray-50);
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+.divider {
+  height: 1px;
+  background: var(--gray-200);
+  margin: 6px 0;
+}
+
+/* 변경 영역 */
+.changeArea {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.changeTitle {
+  font-size: 13px;
+  font-weight: 950;
+  color: var(--text-primary);
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.actionBtn {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--gray-200);
+  background: linear-gradient(180deg, var(--bg-eco-light), var(--bg-primary));
+  color: var(--text-eco);
+  font-size: 13px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.actionBtn:hover {
+  filter: brightness(0.99);
+}
+
+.helper {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+/* 반응형 */
+@media (max-width: 980px) {
+  .inner {
+    grid-template-columns: 1fr;
+  }
+
+  .profileCard {
+    max-width: 520px;
+  }
+
+  .field {
+    grid-template-columns: 80px 1fr;
+  }
+}

--- a/my-react-app/src/components/mypage/StatSummary.jsx
+++ b/my-react-app/src/components/mypage/StatSummary.jsx
@@ -1,0 +1,24 @@
+import styles from "./StatSummary.module.css";
+
+export default function StatSummary({ impact }) {
+  return (
+    <section className={styles.card}>
+      <h3>환경 기여 통계</h3>
+
+      <ul>
+        <li>
+          <span>완료 퀘스트</span>
+          <strong>{impact.completedQuests}회</strong>
+        </li>
+        <li>
+          <span>CO₂ 절감</span>
+          <strong>{impact.totalCo2Gram} g</strong>
+        </li>
+        <li>
+          <span>나무 효과</span>
+          <strong>{impact.totalTreeCount} 그루</strong>
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/my-react-app/src/components/mypage/StatSummary.module.css
+++ b/my-react-app/src/components/mypage/StatSummary.module.css
@@ -1,0 +1,85 @@
+.card {
+  background: var(--bg-primary);
+  border: 1px solid var(--gray-200);
+  border-radius: 18px;
+  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.06);
+  padding: 14px;
+  overflow: hidden;
+}
+
+.header {
+  margin-bottom: 10px;
+}
+
+.title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 950;
+  letter-spacing: -0.02em;
+}
+
+.desc {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+@media (max-width: 520px) {
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+}
+
+.metric {
+  border: 1px solid var(--gray-200);
+  border-radius: 14px;
+  padding: 12px;
+  background: linear-gradient(180deg, var(--bg-eco-light), var(--bg-primary));
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.value {
+  font-size: 18px;
+  font-weight: 950;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+.hint {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.35;
+}
+
+.tip {
+  margin-top: 12px;
+  border-radius: 14px;
+  padding: 12px;
+  background: var(--bg-earth);
+  border: 1px solid var(--earth-100);
+}
+
+.tipTitle {
+  font-size: 12px;
+  font-weight: 900;
+  color: var(--earth-700);
+  margin-bottom: 6px;
+}
+
+.tipText {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}

--- a/my-react-app/src/pages/MyPage/MyPage.jsx
+++ b/my-react-app/src/pages/MyPage/MyPage.jsx
@@ -1,0 +1,75 @@
+import { useCallback, useState } from "react";
+import styles from "./MyPage.module.css";
+
+import ItemPickerModal from "../../components/mypage/ItemPickerModal";
+import MyPageTabPanel from "../../components/mypage/MyPageTabPanel";
+import MyPageTabs from "../../components/mypage/MyPageTabs";
+import PointWallet from "../../components/mypage/PointWallet";
+import ProfileSection from "../../components/mypage/ProfileSection";
+import StatSummary from "../../components/mypage/StatSummary";
+
+const TABS = [
+  { key: "posts", label: "내가 쓴 글" },
+  { key: "diary", label: "환경 일기" },
+  { key: "items", label: "보유 아이템" },
+];
+
+const DUMMY = {
+  user: {
+  presetId: "legendary-6",
+  profileImage: "https://placehold.co/72x72",
+  titleId: "normal-1",
+  badgeId: "legendary-1",
+  userName: "유지훈",
+
+  nickname: "닉네임",
+  id: "testId",
+  region: "서울 · 강남구",
+  address: "서울시 강남구 어딘가 123",
+  gender: "M",
+  birth: "2002-05-12",
+  },
+  impact: {
+    completedQuests: 27,
+    totalCo2Gram: 18450,
+    totalTreeCount: 12,
+  },
+  wallet: {
+    nowPoint: 1320,
+    totalEarnedPoint: 4200,
+    totalSpentPoint: 2880,
+  },
+};
+
+export default function MyPage() {
+  const [activeTab, setActiveTab] = useState("posts");
+  const [modalType, setModalType] = useState(null);
+
+  const openModal = useCallback((type) => setModalType(type), []);
+  const closeModal = useCallback(() => setModalType(null), []);
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.container}>
+        <ProfileSection user={DUMMY.user} onOpenModal={openModal} />
+
+        <div className={styles.grid}>
+          <StatSummary impact={DUMMY.impact} />
+          <PointWallet wallet={DUMMY.wallet} />
+        </div>
+
+        <MyPageTabs
+          tabs={TABS}
+          activeTab={activeTab}
+          onChange={setActiveTab}
+        />
+
+        <MyPageTabPanel activeTab={activeTab} />
+      </div>
+
+      {modalType && (
+        <ItemPickerModal type={modalType} onClose={closeModal} />
+      )}
+    </div>
+  );
+}

--- a/my-react-app/src/pages/MyPage/MyPage.module.css
+++ b/my-react-app/src/pages/MyPage/MyPage.module.css
@@ -1,0 +1,32 @@
+.page {
+  height: 100vh;
+  background: var(--bg-secondary);
+  overflow: auto;
+}
+
+.container {
+  width: 80%;
+  height: 100vh;
+   max-width: 1200px;   
+  min-width: 960px;    
+  margin: 0 auto;
+  padding: 18px 0 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 14px;
+}
+
+@media (max-width: 980px) {
+  .container {
+    width: 92%;
+  }
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/my-react-app/src/shared/constants/items/backgroundItems.js
+++ b/my-react-app/src/shared/constants/items/backgroundItems.js
@@ -1,0 +1,14 @@
+export const BACKGROUND_ITEMS = [
+  {
+    id: "legendary-6",         // ✅ profileBackgrounds.js presetId와 동일
+    grade: "legendary",
+    name: "오로라 민트",
+    description: "최상급 유저를 위한 빛의 그라데이션",
+    price: 1800,
+  },
+];
+
+export function getBackgroundItem(presetId) {
+  if (!presetId) return null;
+  return BACKGROUND_ITEMS.find((it) => it.id === presetId) ?? null;
+}

--- a/my-react-app/src/shared/constants/items/badgeItems.js
+++ b/my-react-app/src/shared/constants/items/badgeItems.js
@@ -1,0 +1,14 @@
+export const BADGE_ITEMS = [
+  {
+    id: "legendary-1",       
+    grade: "legendary",
+    name: "지구 수호자",
+    description: "누적 CO₂ 절감 목표를 달성한 증표",
+    price: 1200,
+  },
+];
+
+export function getBadgeItem(badgeId) {
+  if (!badgeId) return null;
+  return BADGE_ITEMS.find((it) => it.id === badgeId) ?? null;
+}

--- a/my-react-app/src/shared/constants/items/index.js
+++ b/my-react-app/src/shared/constants/items/index.js
@@ -1,0 +1,4 @@
+export { BACKGROUND_ITEMS, getBackgroundItem } from "./backgroundItems";
+export { BADGE_ITEMS, getBadgeItem } from "./badgeItems";
+export { getTitleItem, TITLE_ITEMS } from "./titleItems";
+

--- a/my-react-app/src/shared/constants/items/titleItems.js
+++ b/my-react-app/src/shared/constants/items/titleItems.js
@@ -1,0 +1,15 @@
+export const TITLE_ITEMS = [
+  {
+    id: "normal-1",            
+    grade: "normal",
+    name: "에코 입문자",
+    description: "환경 보호를 처음 시작한 사용자",
+    price: 0,
+  },
+  // 나머지 계속 추가
+];
+
+export function getTitleItem(titleId) {
+  if (!titleId) return null;
+  return TITLE_ITEMS.find((it) => it.id === titleId) ?? null;
+}


### PR DESCRIPTION
## 🔀 Pull Request Summary

### 📌 관련 Issue
- close #3 

---

### ✨ 작업 내용
- 핵심은 렌더링 자원(이미지/색 프리셋)과 아이템 메타(이름/설명/가격/등급)를 분리하고, 동일한 id로 연결하는 구조입니다

src/
  assets/
    badges/
      legendary/legendary-1.png ...
    titles/
      normal/normal-1.png ...
    # (배경은 이미지가 아니라 색 프리셋이라 assets에 파일이 없을 수도 있음)

  shared/constants/
    badgeAssets.js               # badgeId -> 이미지 import 매핑
    titleAssets.js               # titleId -> 이미지 import 매핑
    profileBackgrounds.js        # presetId -> 배경 컬러 프리셋(gradient/ring 등)

    items/                       # ✅ 아이템 메타데이터(객체) 추가 폴더
      badgeItems.js              # badgeId -> {name, description, price, grade}
      titleItems.js              # titleId -> {name, description, price, grade}
      backgroundItems.js         # presetId -> {name, description, price, grade}
      index.js                   # (선택) re-export 용

- 역할 분리(중요)

badgeAssets.js / titleAssets.js
→ UI 렌더링 전용: id → 이미지(src) 매핑만 담당

profileBackgrounds.js
→ UI 렌더링 전용: presetId → 색/링/그라데이션 프리셋만 담당

shared/constants/items/*
→ 비즈니스 데이터: id → 이름/설명/가격/등급 같은 “아이템 객체” 담당

- id 규칙

뱃지: badgeId (ex. "legendary-1")는 badgeAssets.js 키 + badgeItems.js id와 동일

칭호: titleId (ex. "normal-1")는 titleAssets.js 키 + titleItems.js id와 동일

배경: presetId (ex. "legendary-6")는 profileBackgrounds.js 프리셋 id + backgroundItems.js id와 동일

- UI에서 쓰는 방식 예시

이미지 표시: getBadgeAsset(id) / getTitleAsset(id) 사용

상점/모달 표시(이름/설명/가격): getBadgeItem(id) / getTitleItem(id) / getBackgroundItem(id) 사용

배경은 이미지가 아니라 presetId로 색 프리셋을 매핑해서 UI에 적용



“상점/보유/장착 로직은 items/*의 메타데이터를 기준으로 만들고, 화면 렌더링(이미지/색)은 *Assets.js / profileBackgrounds.js 매핑을 사용하면 됩니다”

---

### ✅ 체크리스트
- [ ] develop 브랜치로 PR을 보냈습니다.
- [ ] 관련 Issue와 연결했습니다.
- [ ] 빌드 및 실행에 문제가 없습니다.
- [ ] 불필요한 로그 / 주석을 제거했습니다.

---

### 📎 참고 사항 (선택)
리뷰어가 알아야 할 사항이 있다면 작성해주세요.
