### PR TITLE
[FIX] 커뮤니티, 건의사항 검색 수정

### DIFF
--- a/my-react-app/src/components/community/CommunityWriteModal.jsx
+++ b/my-react-app/src/components/community/CommunityWriteModal.jsx
@@ -96,7 +96,7 @@ function CommunityWriteModal({ isOpen, onClose, postId, onSuccess }) {
   const resetToOriginal = () => {
     setConfirmModal({
       isOpen: true,
-      message: "원본 상태로 되돌렸습니다.", // 메시지만 살짝 수정 (확인용)
+      message: "원본 상태로 되돌리시겠습니까?", 
       onConfirm: () => {
         setCategory(originalData.category);
         setTitle(originalData.title);
@@ -117,7 +117,7 @@ function CommunityWriteModal({ isOpen, onClose, postId, onSuccess }) {
       if (title || content || selectedFiles.length > 0) {
         setConfirmModal({
           isOpen: true,
-          message: "내용이 초기화되었습니다.", // 알림 메시지 형태로 변경
+          message: "작성 중인 내용을 모두 지우시겠습니까?", // 알림 메시지 형태로 변경
           onConfirm: () => {
             resetForm();
             setConfirmModal({ isOpen: false, message: "", onConfirm: () => {} })
@@ -214,7 +214,7 @@ function CommunityWriteModal({ isOpen, onClose, postId, onSuccess }) {
     if (postId && hasChanges()) {
       setConfirmModal({
         isOpen: true,
-        message: "작성을 취소하고 닫습니다.", // 알림 문구
+        message: "변경된 내용이 있습니다. 정말 닫으시겠습니까?", 
         onConfirm: () => {
           resetForm();
           onClose();
@@ -227,7 +227,7 @@ function CommunityWriteModal({ isOpen, onClose, postId, onSuccess }) {
     if (!postId && (title || content || selectedFiles.length > 0)) {
       setConfirmModal({
         isOpen: true,
-        message: "작성을 취소하고 닫습니다.", // 알림 문구
+        message: "작성 중인 내용이 있습니다. 정말 닫으시겠습니까?", 
         onConfirm: () => {
           resetForm();
           onClose();
@@ -269,14 +269,15 @@ function CommunityWriteModal({ isOpen, onClose, postId, onSuccess }) {
 
           <div className={styles.formRow}>
             <label className={styles.formLabel}><span className={styles.required}>*</span> 제목</label>
-            <Input
-              placeholder="제목을 입력하세요 (최대 200자)"
-              maxLength={200}
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              fullWidth
-              style={{ color: "var(--gray-400)" }}
-            />
+            <div className={styles.titleInput}>  
+              <Input
+                placeholder="제목을 입력하세요 (최대 200자)"
+                maxLength={200}
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                fullWidth
+              />
+            </div>
           </div>
 
           <div className={styles.formRow}>
@@ -358,9 +359,10 @@ function CommunityWriteModal({ isOpen, onClose, postId, onSuccess }) {
     {/* ── [기존 유지] 확인 모달 (type="alert" 적용하여 확인 버튼만 노출) ── */}
     <CustomModal
       isOpen={confirmModal.isOpen}
-      type="alert" 
+      type="confirm" 
       message={confirmModal.message}
       onConfirm={confirmModal.onConfirm}
+      onCancel={() => setConfirmModal({ isOpen: false, message: "", onConfirm: () => {} })}
       zIndex={15000}
     />
   </>

--- a/my-react-app/src/components/community/CommunityWriteModal.module.css
+++ b/my-react-app/src/components/community/CommunityWriteModal.module.css
@@ -65,15 +65,6 @@
 
 .required { color: #ef4444; }
 
-.titleInput :global(input) {
-  color: var(--gray-700); /* 실제 입력되는 글자 색상 */
-}
-
-.titleInput :global(input::placeholder) {
-  color: var(--gray-400); /* placeholder 글자 색상 */
-  opacity: 1; 
-}
-
 /* 카테고리 버튼 */
 .categoryGroup {
   display: flex;
@@ -117,7 +108,15 @@
   transition: border-color 0.15s;
 }
 .inputTitle:focus { border-color: var(--green-400); }
-.inputTitle::placeholder { color: var(--gray-400); }
+
+.titleInput :global(input) {
+  color: var(--gray-700); 
+}
+
+.titleInput :global(input::placeholder) {
+  color: var(--gray-400);
+  opacity: 1; 
+}
 
 /* 내용 입력 */
 .textareaContent {

--- a/my-react-app/src/pages/CommunityPage/CommunityDetailPage.jsx
+++ b/my-react-app/src/pages/CommunityPage/CommunityDetailPage.jsx
@@ -405,7 +405,7 @@ function CommunityDetailPage() {
           </div>
         </div>
 
-        <article className={styles.postCard}>
+        <div className={styles.postCard}>
           <header className={styles.postHeader}>
             <div className={styles.headerMeta}>
               <div className={styles.headerTop}>
@@ -444,7 +444,7 @@ function CommunityDetailPage() {
               ))}
             </div>
           )}
-        </article>
+        </div>
 
         <section className={styles.commentSection}>
           <h3 className={styles.commentTitle}>댓글 <span className={styles.commentCountBadge}>{replies.length}</span></h3>
@@ -528,19 +528,24 @@ function CommunityDetailPage() {
         )}
         <CommunityWriteModal isOpen={isEditModalOpen} onClose={() => setIsEditModalOpen(false)} postId={postId} onSuccess={(msg) => window.location.reload()} />
         
-        {/* 댓글 수정 간이 모달 */}
-        {editModalConfig.isOpen && (
-          <div className={styles.replyEditModalOverlay}>
-            <div className={styles.replyEditModalContent}>
-              <h3>댓글 수정</h3>
-              <textarea value={editContent} onChange={(e) => setEditContent(e.target.value)} className={styles.replyEditTextarea} />
-              <div className={styles.replyEditBtns}>
-                <button onClick={() => setEditModalConfig({ isOpen: false, replyId: null, currentContent: "" })}>취소</button>
-                <button onClick={handleReplyEditSubmit} className={styles.replyEditSubmitBtn}>수정</button>
-              </div>
+        {/* 댓글 수정 모달 */}
+        <CustomModal 
+          isOpen={editModalConfig.isOpen} 
+          type="confirm" 
+          message={
+            <div className={styles.editWrapper}>
+              <h3 className={styles.editTitle}>댓글 수정</h3>
+              <textarea 
+                value={editContent} 
+                onChange={(e) => setEditContent(e.target.value)} 
+                className={styles.replyEditModal}
+                placeholder="수정할 내용을 입력하세요."
+              />
             </div>
-          </div>
-        )}
+          } 
+          onConfirm={handleReplyEditSubmit} 
+          onCancel={() => setEditModalConfig({ isOpen: false, replyId: null, currentContent: "" })} 
+        />
       </div>
     </div>
   );

--- a/my-react-app/src/pages/CommunityPage/CommunityDetailPage.module.css
+++ b/my-react-app/src/pages/CommunityPage/CommunityDetailPage.module.css
@@ -512,6 +512,23 @@
   color: var(--gray-400);
 }
 
+.replyEditModal {
+  width: 100%;
+  min-height: 60px; 
+  padding: 16px;
+  resize: none; 
+  color: var(--gray-700); 
+}
+
+.replyEditModal:focus {
+  border-color: var(--green-400);
+}
+
+.replyEditModal::placeholder {
+  color: var(--gray-700);
+  font-weight: 800;
+}
+
 /* ── 신고된 댓글 표시 ── */
 .highlight {
   background-color: #fff1f0; 

--- a/my-react-app/src/pages/CommunityPage/CommunityPage.jsx
+++ b/my-react-app/src/pages/CommunityPage/CommunityPage.jsx
@@ -182,7 +182,7 @@ const handleWriteClick = () => {
                   <span className={styles.writer}>{post.name}</span>
                   <span className={styles.dot}>•</span>
                   <span className={styles.date}>
-                    {String(post.createdAt ?? "").slice(0, 10)}
+                    {String(post.updatedAt ?? "").slice(0, 10)}
                   </span>
                 </div>
 


### PR DESCRIPTION
커뮤니티, 건의사항 검색 수정

## 🔀 Pull Request Summary

### 📌 관련 Issue
- close #이슈번호

---

### ✨ 작업 내용
이번 PR에서 수행한 작업을 간단히 설명해주세요.


---

### ✅ 체크리스트
- [ ] develop 브랜치로 PR을 보냈습니다.
- [ ] 관련 Issue와 연결했습니다.
- [ ] 빌드 및 실행에 문제가 없습니다.
- [ ] 불필요한 로그 / 주석을 제거했습니다.

---

### 📎 참고 사항 (선택)
리뷰어가 알아야 할 사항이 있다면 작성해주세요.

### 커뮤니티 페이지

> **1. 커뮤니티 목록 조회**
> 
- [ ]  목록 페이지 처리 확인
- [ ]  상단에 카테고리 별 필터링 확인
- [ ]  하단에 검색바 조회 확인
    - [ ]  제목으로 검색 (키워드가 포함되는 것들)
    - [ ]  내용으로 검색 (키워드가 포함되는 것들)
    - [ ]  작성자로 검색 (키워드랑 일치해야 함)
- [ ]  카테고리 별 필터링 아래에 총 게시글 수 확인
- [ ]  게시글 목록 카드 정보 확인
    - [ ]  카테고리 뱃지
    - [ ]  작성자 (이름)
    - [ ]  작성일
    - [ ]  제목 및 내용
        - [ ]  첨부파일이 포함된 게시글 → 제목 옆에 🖼️ 아이콘
    - [ ]  👁️‍🗨️(조회수), ♥️(좋아요 수), 💬(댓글 수)

> **2. 커뮤니티 게시글 작성 (목록 페이지 우측 상단 “글 쓰기” 버튼)**
> 
- [ ]  카테고리 선택
- [ ]  제목 작성 (최대 200자)
- [ ]  내용 작성 (글자 수 많아지면 textarea 옆에 스크롤)
- [x]  파일 첨부
    - [ ]  첨부하면 하단에 “파일이름.확장자” + 삭제 버튼

- [x]  필수 항목 (카테고리, 제목, 내용) 미작성 → alert 메시지
- [x]  작성된 내용이 없는 상태 → alert 메시지 없이 초기화 / 닫기(X) 가능
- [x]  작성된 내용이 있는 상태
    - [ ]  → 초기화 / 닫기(X) 버튼 클릭 : alert 메시지 (작성 중인 내용이 있습니다. 초기화 / 닫기 하겠습니까?)

> **3. 커뮤니티 게시글 상세 조회**
> 
- [x]  왼쪽 상단에 좋아요 & 신고 버튼
    - [ ]  본인이 작성한 글 → 좋아요 클릭 불가, 신고 버튼 안 보이도록 설정
- [x]  좋아요 버튼 눌렀을 때 +1 / 한번 더 클릭하면 -1 (취소) 처리
- [ ]  오른쪽 상단에 목록으로 돌아가기 버튼
- [ ]  수정하기, 삭제하기 버튼 (작성자 본인일 경우에만 버튼 보임)
    - [x]  원본 글에 해당 하는 정보가 작성되어 있음
    - [x]  원본에 있던 첨부파일은 이미지로 보여지고,
        
        삭제를 위해 체크박스 클릭하면 이미지가 빨간 배경으로 변하고 “삭제 예정” 문구 추가
        
    - [ ]  수정된 내용이 없는 상태 → alert 메시지 없이 초기화 / 닫기(X) 가능
    - [ ]  수정된 내용이 있는 상태
        - [ ]  → 초기화(원본 상태) / 닫기(X) 버튼 클릭 : alert 메시지 (작성 중인 내용이 있습니다. 초기화 / 닫기 하겠습니까?)
    - [ ]  삭제 버튼 → 취소 / 확인 버튼 + “삭제하겠습니까?” 메시지

- [ ]  게시글 내용 div
    - [x]  왼쪽 상단에 프로필 → 클릭 시 멤버 상세 보기 모달
    - [x]  오른쪽 상단에 카테고리 뱃지 / 작성일 / 조회수
    - [x]  게시글 제목 (굵은 글씨)
    
    ---
    
    - [x]  게시글 내용 (일반 글씨)
    
    ---
    
    - [x]  첨부 파일 이미지
        
        → 이미지 클릭하면 확대 보기 가능
        
    
- [ ]  댓글 목록 div
    - [ ]  댓글 수 확인
    - [ ]  댓글 입력 input 상자 → 일반 댓글
    - [ ]  등록된 댓글
        - [ ]  멤버 상세 조회 버튼 + 모달
        - [ ]  댓글 내용
        - [ ]  좋아요 버튼
            - [ ]  작성자 본인은 좋아요 클릭 불가
            - [ ]  버튼 클릭 시 +1 / 한 번 더 클릭 시 -1 (취소)
        - [ ]  신고 버튼 (작성자 본인일 경우 안 보임)
        - [ ]  답글 → 하단에 초록색 input 상자 (대댓글)
            - [ ]  답글 입력했을 때 부모 댓글 바로 밑에 목록 추가 되는 지 확인
        - [ ]  수정 (작성자 본인)
            - [ ]  (모달) 수정할 내용 입력 + 취소 / 수정 버튼
        - [ ]  삭제 (작성자 본인)
            - [ ]  → 취소 / 확인 버튼 + “삭제하겠습니까?” 메시지
            - [ ]  삭제 되어도 목록에 보여짐 “삭제된 댓글입니다.”

### 건의사항 페이지

> **1. 건의사항 목록 조회**
> 
- [ ]  목록 페이지 처리 확인
- [ ]  상단에 진행상태 별 필터링 확인
- [ ]  하단에 검색바 조회 확인
    - [ ]  제목으로 검색 (키워드가 포함되는 것들)
    - [ ]  내용으로 검색 (키워드가 포함되는 것들)
    - [ ]  작성자로 검색 (키워드랑 일치해야 함)
- [ ]  진행상태 별 필터링 아래에 총 게시글 수 확인
- [ ]  게시글 목록 카드 정보 확인
    - [ ]  자주 묻는 질문 → FAQ 뱃지, 목록 카드: 보라색 배경
    - [ ]  진행상태 뱃지
    - [ ]  작성자 (이름)
    - [ ]  작성일
    - [ ]  제목 및 내용
    - [ ]  비공개 게시글 → 우측 상단에 🔒 아이콘
    - [ ]  👁️‍🗨️(조회수)

> **2. 건의사항 게시글 작성 (목록 페이지 우측 상단 “글 쓰기” 버튼)**
> 
- [ ]  제목 작성 (최대 200자)
- [ ]  내용 작성 (글자 수 많아지면 textarea 옆에 스크롤)
- [ ]  공개 설정 (공개 / 비공개 - radio 타입)

- [ ]  필수 항목 (카테고리, 제목, 내용) 미작성 → alert 메시지
- [ ]  작성된 내용이 없는 상태 → alert 메시지 없이 초기화 / 닫기(X) 가능
- [ ]  작성된 내용이 있는 상태
    - [ ]  → 초기화 / 닫기(X) 버튼 클릭 : alert 메시지 (작성 중인 내용이 있습니다. 초기화 / 닫기 하겠습니까?)

> **3. 건의사항 게시글 상세 조회**
> 
- [ ]  비공개 건의글 클릭 시 “비공개 건의글은 작성자와 관리자만 확인할 수 있습니다.” 메시지
- [ ]  오른쪽 상단에 목록으로 돌아가기 버튼
- [ ]  수정하기, 삭제하기 버튼 (작성자 본인일 경우에만 버튼 보임)
    - [ ]  수정된 내용이 없는 상태 → alert 메시지 없이 초기화 / 닫기(X) 가능
    - [ ]  수정된 내용이 있는 상태
        - [ ]  → 초기화(원본 상태) / 닫기(X) 버튼 클릭 : alert 메시지 (작성 중인 내용이 있습니다. 초기화 / 닫기 하겠습니까?)
    - [ ]  삭제 버튼 → 취소 / 확인 버튼 + “삭제하겠습니까?” 메시지

- [ ]  게시글 내용 div
    - [ ]  왼쪽 상단에 프로필 → 클릭 시 멤버 상세 보기 모달
    - [ ]  오른쪽 상단에 진행상태 뱃지 / 작성일 / 조회수
    - [ ]  게시글 제목 (굵은 글씨)
    
    ---
    
    - [ ]  게시글 내용 (일반 글씨)
    
- [ ]  관리자 답변 div
    - [ ]  관리자 답변이 추가되지 않은 경우
        
        → “아직 답변이 등록되지 않았습니다. 답변을 기다려주세요.”
        
    - [ ]  관리자 답변이 추가된 경우
        
        → 관리자 답변 내용이 보이고, 답변 배경색이 초록색으로 변경
        

### < 관리자 기능 >

> **1.  건의사항 페이지 - 상태관리**
> 
- [ ]  상태 관리 버튼 클릭하면 현재 상태값이 기본으로 선택되어 있음
- [ ]  진행 중 / 답변 완료로 상태 변경 처리 가능
    - [ ]  답변 완료 → 해당 건의글에 관리자 답변을 추가한 후에 활성화 가능

 ****

> **2.  신고 관리 페이지 - 상태관리**
> 
- [x]  신고 대상이랑 신고 사유에 따른 필터링
- [x]  검색 기능 확인
- [x]  각 상태 값에 따라서 3가지 목록으로 나뉘어져 있음

- [x]  접수 완료일 때만 상태 변경이 가능함
- [x]  상태 관리 버튼 → 처리 완료 / 반려
- [x]  처리 완료랑 반려 상태인 것
    - [ ]  상세 정보 버튼 → 처리 기록을 확인 가능
- [ ]  각 신고글 클릭 → 상세보기 페이지
    - [ ]  목록으로 가기 버튼
    - [ ]  상세보기 페이지에서도 상태 관리 가능
    - [ ]  원본 게시글 보기 → 해당 커뮤니티 게시글 / 댓글로 이동
    - [ ]  커뮤니티 댓글의 경우 배경색을 빨강으로 해서 신고된 댓글인 것을 표시

 
> 누적 신고 수 테스트 용으로 2회로 설정해 두었습니다.
> 2회 누적되면 STATUS = B로 자동 변경됩니다.
> 커뮤니티 게시글 경우에는 목록에서는 사라지게 설정
> 커뮤니티 게시글 - 댓글 경우에는 "신고된 댓글입니다" 로 표시
> 신고글 상세보기에 원본 게시글 보기
    - [ ]  해당하는 커뮤니티 게시글 , 댓글 로 이동 (새로운 창 열림)


